### PR TITLE
some links ending with .html should be .markdown

### DIFF
--- a/puppet/3.8/modules_fundamentals.markdown
+++ b/puppet/3.8/modules_fundamentals.markdown
@@ -4,12 +4,12 @@ title: "Module Fundamentals"
 canonical: "/puppet/latest/reference/modules_fundamentals.html"
 ---
 
-[modulepath]: ./dirs_modulepath.html
-[installing]: ./modules_installing.html
-[publishing]: ./modules_publishing.html
-[documentation]: ./modules_documentation.html
+[modulepath]: ./dirs_modulepath.markdown
+[installing]: ./modules_installing.markdown
+[publishing]: ./modules_publishing.markdown
+[documentation]: ./modules_documentation.markdown
 
-[plugins]: ./plugins_in_modules.html
+[plugins]: ./plugins_in_modules.markdown
 
 [external facts]: {{facter}}/custom_facts.html#external-facts
 [custom facts]: {{facter}}/custom_facts.html


### PR DESCRIPTION
The files were renamed somewhere in time to .markdown and originally were (I think) .html . This is just adjusting the reality.